### PR TITLE
[bug] Fix liquid syntax error for email

### DIFF
--- a/_layouts/team.html
+++ b/_layouts/team.html
@@ -12,5 +12,5 @@ layout: single
 {% endif %}
 <p>{{ member.position }}</p>
 <p>{{ member.keywords }}</p>
-<p><a href="{{ mailto:member.email }}">{{ member.email }}</a></p>
+<p><a href="mailto:{{ member.email }}">{{ member.email }}</a></p>
 {% endfor %}


### PR DESCRIPTION
Fix bug when presenting the email in liquid syntax. Pressing the email now opens the email client.